### PR TITLE
/hellotime でリクエストしたときに Hello World と現在時刻を返す API を実装

### DIFF
--- a/src/main/java/com/hellotime/assignment6/HelloController.java
+++ b/src/main/java/com/hellotime/assignment6/HelloController.java
@@ -3,10 +3,27 @@ package com.hellotime.assignment6;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
 @RestController
 public class HelloController {
     @GetMapping("/hello")
     public String hello() {
         return "Hello World";
+    }
+
+    @GetMapping("/hellotime")
+    public Map<String, String> hellotime() {
+        Map<String, String> response = new HashMap<>();
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
+        LocalDateTime now = LocalDateTime.now();
+
+        response.put("time", dtf.format(now));
+        response.put("message", "Hello World");
+
+        return response;
     }
 }


### PR DESCRIPTION
# 概要
`/hellotime` とリクエストしたときに、「`Hello World` と現在時刻」をJSON形式で返すように変更を加えました。
また、ここでの現在時刻とは、コードが実行された瞬間のシステム時刻とリクエスト（アクセス）した瞬間はほぼ同義としたうえで、現在時刻としています。

## 動作確認結果
Postmanを使用し、`/hellotime` とリクエストしたときの下記3点を確認しました。
- レスポンスボディが「`Hello World` と現在時刻」であること。（画像1）
- レスポンスのステータスコードが 200 であること。（画像1）
- Content-Type が JSON 形式であること。（画像1・2）
![image](https://github.com/Ema-Sakai/Assignment-6/assets/166620990/0fc5381f-719f-4225-8688-2dbcdae8a864)

![image](https://github.com/Ema-Sakai/Assignment-6/assets/166620990/f94a9397-5c0c-4789-8184-71b0053e2fa2)

## コミットハッシュ
9e879dd8362c68a5ef5ec5c3d5e76ab57badb003